### PR TITLE
Update doc: supported Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # String#scrub
 
-String#scrub for Ruby 2.0.0
+String#scrub for Ruby 2.0.0 and 1.9.3
 
 ## Installation
 


### PR DESCRIPTION
string-scrub is now supporting 1.9.3 is really great news. awesome :raised_hands:
